### PR TITLE
Initial release

### DIFF
--- a/.github/workflows/autotag.yml
+++ b/.github/workflows/autotag.yml
@@ -1,0 +1,15 @@
+name: Tag and Release
+on:
+ push:
+  branches:
+    - main
+permissions:
+  contents: write
+jobs:
+  tag-release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: pantheon-systems/action-autotag@v0
+        with:
+          gh-token: ${{ github.token }}   

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,11 @@
+name: Lint
+on: [pull_request]
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install dependencies
+        run: composer install
+      - name: Lint
+        run: composer lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,8 +15,8 @@ jobs:
       - name: Validate that bin files were copied
         run: |
           cd ${{ github.workspace }}/test_proj
-          test -d bin || echo "❌ bin directory not found" >&2 && exit 1
-          test -f bin/install-wp-tests.sh || echo "❌ bin/install-wp-tests.sh not found" >&2 && exit 1
-          test -f bin/install-local-tests.sh || echo "❌ bin/install-local-tests.sh not found" >&2 && exit 1
-          test -f bin/phpunit-test.sh || echo "❌ bin/phpunit-test.sh not found" >&2 && exit 1
+          test -d bin || $(echo "❌ bin directory not found" >&2 && exit 1)
+          test -f bin/install-wp-tests.sh || $(echo "❌ bin/install-wp-tests.sh not found" >&2 && exit 1)
+          test -f bin/install-local-tests.sh || $(echo "❌ bin/install-local-tests.sh not found" >&2 && exit 1)
+          test -f bin/phpunit-test.sh || $(echo "❌ bin/phpunit-test.sh not found" >&2 && exit 1)
           echo "✅ All bin files found"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,7 @@ jobs:
           mkdir test_proj && cd test_proj
           composer init --name test/test --no-interaction --type=library --stability=dev
           composer config repositories.wpunit-helpers '{"type": "vcs", "url": "https://github.com/pantheon-systems/wpunit-helpers.git"}'
+          composer config config.allow-plugins '{"pantheon-systems/wpunit-helpers": true}'
           composer require --dev pantheon-systems/wpunit-helpers:dev-${{ github.head_ref }}
       - name: Validate that bin files were copied
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,22 @@
+name: Test Plugin
+on: [pull_request]
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup barebones project
+        run: |
+          mkdir test_proj && cd test_proj
+          composer init --name test/test --no-interaction --type=library --stability=dev --prefer-dist
+          composer config repositories.wpunit-helpers '{"type": "vcs", "url": "https://github.com/pantheon-systems/wpunit-helpers.git"}'
+          BRANCH_NAME=${GITHUB_REF#refs/heads/}
+          composer require --dev pantheon-systems/wpunit-helpers:dev-$BRANCH_NAME
+      - name: Validate that bin files were copied
+        run: |
+          set -e
+          cd ${{ github.workspace }}/test_proj
+          test -f bin/install-wp-tests.sh || echo "❌ bin/install-wp-tests.sh not found" >&2
+          test -f bin/install-local-tests.sh || echo "❌ bin/install-local-tests.sh not found" >&2
+          test -f bin/phpunit-test.sh || echo "❌ bin/phpunit-test.sh not found" >&2
+          echo "✅ All bin files found"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
       - name: Setup barebones project
         run: |
           mkdir test_proj && cd test_proj
-          composer init --name test/test --no-interaction --type=library --stability=dev --prefer-dist
+          composer init --name test/test --no-interaction --type=library --stability=dev
           composer config repositories.wpunit-helpers '{"type": "vcs", "url": "https://github.com/pantheon-systems/wpunit-helpers.git"}'
           BRANCH_NAME=${GITHUB_REF#refs/heads/}
           composer require --dev pantheon-systems/wpunit-helpers:dev-$BRANCH_NAME

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,10 +14,9 @@ jobs:
           composer require --dev pantheon-systems/wpunit-helpers:dev-${{ github.head_ref }}
       - name: Validate that bin files were copied
         run: |
-          set -e
           cd ${{ github.workspace }}/test_proj
-          test -d bin || echo "❌ bin directory not found" >&2
-          test -f bin/install-wp-tests.sh || echo "❌ bin/install-wp-tests.sh not found" >&2
-          test -f bin/install-local-tests.sh || echo "❌ bin/install-local-tests.sh not found" >&2
-          test -f bin/phpunit-test.sh || echo "❌ bin/phpunit-test.sh not found" >&2
+          test -d bin || echo "❌ bin directory not found" >&2 && exit 1
+          test -f bin/install-wp-tests.sh || echo "❌ bin/install-wp-tests.sh not found" >&2 && exit 1
+          test -f bin/install-local-tests.sh || echo "❌ bin/install-local-tests.sh not found" >&2 && exit 1
+          test -f bin/phpunit-test.sh || echo "❌ bin/phpunit-test.sh not found" >&2 && exit 1
           echo "✅ All bin files found"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,7 @@ jobs:
         run: |
           set -e
           cd ${{ github.workspace }}/test_proj
+          ls -la
           test -f bin/install-wp-tests.sh || echo "❌ bin/install-wp-tests.sh not found" >&2
           test -f bin/install-local-tests.sh || echo "❌ bin/install-local-tests.sh not found" >&2
           test -f bin/phpunit-test.sh || echo "❌ bin/phpunit-test.sh not found" >&2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,7 @@ jobs:
           mkdir test_proj && cd test_proj
           composer init --name test/test --no-interaction --type=library --stability=dev
           composer config repositories.wpunit-helpers '{"type": "vcs", "url": "https://github.com/pantheon-systems/wpunit-helpers.git"}'
-          composer config config.allow-plugins '{"pantheon-systems/wpunit-helpers": true}'
+          composer config allow-plugins.pantheon-systems/wpunit-helpers true
           composer require --dev pantheon-systems/wpunit-helpers:dev-${{ github.head_ref }}
       - name: Validate that bin files were copied
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,12 +11,12 @@ jobs:
           composer init --name test/test --no-interaction --type=library --stability=dev
           composer config repositories.wpunit-helpers '{"type": "vcs", "url": "https://github.com/pantheon-systems/wpunit-helpers.git"}'
           composer config allow-plugins.pantheon-systems/wpunit-helpers true
-          composer require --dev -vvv pantheon-systems/wpunit-helpers:dev-${{ github.head_ref }}
+          composer require --dev pantheon-systems/wpunit-helpers:dev-${{ github.head_ref }}
       - name: Validate that bin files were copied
         run: |
           set -e
           cd ${{ github.workspace }}/test_proj
-          ls -la
+          test -d bin || echo "❌ bin directory not found" >&2
           test -f bin/install-wp-tests.sh || echo "❌ bin/install-wp-tests.sh not found" >&2
           test -f bin/install-local-tests.sh || echo "❌ bin/install-local-tests.sh not found" >&2
           test -f bin/phpunit-test.sh || echo "❌ bin/phpunit-test.sh not found" >&2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,7 @@
 name: Test Plugin
 on: [pull_request]
 jobs:
-  lint:
+  test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
           composer init --name test/test --no-interaction --type=library --stability=dev
           composer config repositories.wpunit-helpers '{"type": "vcs", "url": "https://github.com/pantheon-systems/wpunit-helpers.git"}'
           composer config allow-plugins.pantheon-systems/wpunit-helpers true
-          composer require --dev pantheon-systems/wpunit-helpers:dev-${{ github.head_ref }}
+          composer require --dev -vvv pantheon-systems/wpunit-helpers:dev-${{ github.head_ref }}
       - name: Validate that bin files were copied
         run: |
           set -e

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,8 +10,7 @@ jobs:
           mkdir test_proj && cd test_proj
           composer init --name test/test --no-interaction --type=library --stability=dev
           composer config repositories.wpunit-helpers '{"type": "vcs", "url": "https://github.com/pantheon-systems/wpunit-helpers.git"}'
-          BRANCH_NAME=${GITHUB_REF#refs/heads/}
-          composer require --dev pantheon-systems/wpunit-helpers:dev-$BRANCH_NAME
+          composer require --dev pantheon-systems/wpunit-helpers:dev-${{ github.head_ref }}
       - name: Validate that bin files were copied
         run: |
           set -e

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,8 +15,8 @@ jobs:
       - name: Validate that bin files were copied
         run: |
           cd ${{ github.workspace }}/test_proj
-          test -d bin || $(echo "❌ bin directory not found" >&2 && exit 1)
-          test -f bin/install-wp-tests.sh || $(echo "❌ bin/install-wp-tests.sh not found" >&2 && exit 1)
-          test -f bin/install-local-tests.sh || $(echo "❌ bin/install-local-tests.sh not found" >&2 && exit 1)
-          test -f bin/phpunit-test.sh || $(echo "❌ bin/phpunit-test.sh not found" >&2 && exit 1)
+          test -d bin || (echo "❌ bin directory not found" >&2 && exit 1)
+          test -f bin/install-wp-tests.sh || (echo "❌ bin/install-wp-tests.sh not found" >&2 && exit 1)
+          test -f bin/install-local-tests.sh || (echo "❌ bin/install-local-tests.sh not found" >&2 && exit 1)
+          test -f bin/phpunit-test.sh || (echo "❌ bin/phpunit-test.sh not found" >&2 && exit 1)
           echo "✅ All bin files found"

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,1 @@
+* @pantheon-systems/cms-platform

--- a/README.md
+++ b/README.md
@@ -1,2 +1,58 @@
-# wpunit-helpers
+# WPUnit Helpers
+[![Lint](https://github.com/pantheon-systems/wpunit-helpers/actions/workflows/lint.yml/badge.svg)](https://github.com/pantheon-systems/wpunit-helpers/actions/workflows/lint.yml) ![GitHub](https://img.shields.io/github/license/pantheon-systems/wpunit-helpers) ![GitHub release (latest by date)](https://img.shields.io/github/v/release/pantheon-systems/wpunit-helpers) [![Unofficial Support](https://img.shields.io/badge/Pantheon-Unofficial%20Support-yellow?logo=pantheon&color=FFDC28)](https://docs.pantheon.io/oss-support-levels#unofficial-support)
+
 Unified scripts for installing and running automated WP Unit Tests.
+
+## What is this?
+
+This is a set of scripts that can be used in a WordPress plugin or theme repository to run automated tests using the WP Unit Test Framework built on top of PHPUnit. The Composer plugin will install these scripts into the dependent project's `bin` directory, allowing you to add helper scripts to your `composer.json`.
+
+## What's included?
+
+* `install-wp-tests.sh` - The _de facto_ standard script for installing the WP Unit Test Framework.
+* `install-local-tests.sh` - A helper script for installing WP Unit Tests locally. See [Local Testing](#local-testing) for more information.
+* `phpunit-test.sh` - A helper script for running WP Unit Tests that is intended for use in CI.
+
+## Installation
+
+Use Composer to install this package as a development dependency:
+
+```bash
+composer require --dev pantheon-systems/wpunit-helpers
+```
+
+On installation, the Composer plugin will copy the scripts into the `bin` directory of the dependent project. You can then add the scripts to your `composer.json`:
+
+```json
+{
+	"scripts": {
+		"phpunit": "phpunit --do-not-cache-result",
+		"test": "@phpunit",
+		"test:install": "bin/install-local-tests.sh --no-db",
+		"test:install:withdb": "bin/install-local-tests.sh"
+	}
+}
+```
+
+## Local Testing
+The `install-local-tests.sh` script is highly configurable to allow for a variety of local environment setups. Any parameter that could be passed into `install-wp-tests.sh` is set up as an optional flag in `install-local-tests.sh`. By default, the script with no flags will assume that a new database should be created as `root` with no password.
+
+### Flags
+
+#### `--no-db`
+This flag will skip the database creation step. This is useful if you are using a local database that is already set up.
+
+#### `--dbname`
+This flag will set the name of the database to be created. The default value is `wordpress_test`.
+
+#### `--dbuser`
+This flag will set the username of the database user to be created. The default value is `root`.
+
+#### `--dbpass`
+This flag will set the password of the database user to be created. The default value is an empty string.
+
+#### `--dbhost`
+This flag will set the host of the database to be created. The default value is `127.0.0.1`.
+
+#### `--wpversion`
+This flag will set the version of WordPress to be installed. The default value is `latest`. Using `nightly` here will use the latest nightly build of WordPress.

--- a/bin/phpunit-test.sh
+++ b/bin/phpunit-test.sh
@@ -7,7 +7,7 @@ DIRNAME=$(dirname "$0")
 bash "${DIRNAME}/install-wp-tests.sh" wordpress_test root root 127.0.0.1 latest
 echo "Running PHPUnit on Single Site"
 composer phpunit
-rm -rf $WP_TESTS_DIR $WP_CORE_DIR
+rm -rf "$WP_TESTS_DIR" "$WP_CORE_DIR"
 
 bash "${DIRNAME}/install-wp-tests.sh" wordpress_test root root 127.0.0.1 nightly true
 echo "Running PHPUnit on Single Site (Nightly WordPress)"

--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,12 @@
         }
     ],
     "minimum-stability": "dev",
+    "prefer-stable": true,
     "require": {
         "composer-plugin-api": "^2.3"
+    },
+    "require-dev": {
+        "squizlabs/php_codesniffer": "^3.7"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -20,5 +20,15 @@
     },
     "extra": {
         "class": "Pantheon\\WPUnitHelpers\\Plugin"
+    },
+    "scripts": {
+        "shellcheck": "find bin/ -name \"*.sh\" | grep -v \"install-wp-tests.sh\" | xargs shellcheck",
+        "phpcs": "phpcs --standard=PSR2 src/",
+        "phplint": "find src/ -name '*.php' -exec php -l {} \\;",
+        "lint": [
+            "@shellcheck",
+            "@phpcs",
+            "@phplint"
+        ]
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,13 +4,71 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c1205d96165899443870be19044791a0",
+    "content-hash": "ab8407189fce651913dd9250af8945b6",
     "packages": [],
-    "packages-dev": [],
+    "packages-dev": [
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.7.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/ed8e00df0a83aa96acf703f8c2979ff33341f879",
+                "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.4.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
+            },
+            "bin": [
+                "bin/phpcs",
+                "bin/phpcbf"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Greg Sherwood",
+                    "role": "lead"
+                }
+            ],
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
+            "keywords": [
+                "phpcs",
+                "standards",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/squizlabs/PHP_CodeSniffer/issues",
+                "source": "https://github.com/squizlabs/PHP_CodeSniffer",
+                "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
+            },
+            "time": "2023-02-22T23:07:41+00:00"
+        }
+    ],
     "aliases": [],
     "minimum-stability": "dev",
     "stability-flags": [],
-    "prefer-stable": false,
+    "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
         "composer-plugin-api": "^2.3"

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -82,7 +82,8 @@ class Plugin implements PluginInterface, EventSubscriberInterface
             \"phpunit\": \"phpunit --do-not-cache-result\",
             \"test\": \"@phpunit\",
             \"test:install\": \"bin/install-local-tests.sh --no-db\",
-            \"test:install:withdb\": \"bin/install-local-tests.sh\"}";
+            \"test:install:withdb\": \"bin/install-local-tests.sh\"
+        }";
     
         if (!$filesAreIdentical) {
             $io->write("Done copying files into /bin.");

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -88,7 +88,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface
             $io->write("Done copying files into /bin.");
             $io->write("You can now add the following to your composer.json file: \n $composerIncludes");
         } else {
-            $io->write("/bin files are already up to date");
+            $io->write("/bin files are up to date");
         }
     }
 }

--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -35,11 +35,11 @@ class Plugin implements PluginInterface, EventSubscriberInterface
             'post-install-cmd' => ['copyBinDirectory'],
             'post-update-cmd' => ['copyBinDirectory'],
         );
-    } 
+    }
 
     public function copyBinDirectory()
-    {   
-        $io = $this->io;     
+    {
+        $io = $this->io;
         $vendorDir = $this->composer->getConfig()->get('vendor-dir');
         $binDir = $vendorDir . '/pantheon-systems/wpunit-helpers/bin';
         $targetDir = dirname($vendorDir) . '/bin';
@@ -85,7 +85,8 @@ class Plugin implements PluginInterface, EventSubscriberInterface
             \"test:install:withdb\": \"bin/install-local-tests.sh\"}";
     
         if (!$filesAreIdentical) {
-            $io->write("Done copying files into /bin. You can now add the following to your composer.json file: \n $composerIncludes");
+            $io->write("Done copying files into /bin.");
+            $io->write("You can now add the following to your composer.json file: \n $composerIncludes");
         } else {
             $io->write("/bin files are already up to date");
         }


### PR DESCRIPTION
This adds some additional required files and tests before releasing. Note that the autotag action is expected to fail since we don't already have a tag. That will be created so subsequent merges to `main` will generate a new release.

The main details of what this package does is in the [readme](https://github.com/pantheon-systems/wpunit-helpers/blob/334fb93969d926b0e2d0d457f51c479cb4efc313/README.md). It's a Composer plugin that we can require on WP plugins to include a standardized set of bash files. At this point, most of them have been manually created, but if we ever want to change any of them, we can do so in this plugin, require the plugin in those projects, and pull down the changes from a single source (see https://github.com/pantheon-systems/pantheon-advanced-page-cache/pull/251#discussion_r1350848923)