### PR TITLE
drop composer plugin api dep to 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "composer-plugin-api": "^2.3"
+        "composer-plugin-api": "^2.0"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "^3.7"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ab8407189fce651913dd9250af8945b6",
+    "content-hash": "f050a5ad20df6a5a0ed11f675eecc564",
     "packages": [],
     "packages-dev": [
         {
@@ -71,7 +71,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "composer-plugin-api": "^2.3"
+        "composer-plugin-api": "^2.0"
     },
     "platform-dev": [],
     "plugin-api-version": "2.6.0"


### PR DESCRIPTION
other systems might not have composer 2.3 so we should lower to 2.x for install on any composer 2x system