### PR TITLE
Allow nightly tests to skip

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @pantheon-systems/site-experience
+* @pantheon-systems/site-experience @pantheon-systems/devrel

--- a/README.md
+++ b/README.md
@@ -45,6 +45,21 @@ On installation, the Composer plugin will copy the scripts into the `bin` direct
 }
 ```
 
+## Nightly WordPress tests
+
+By default, the `phpunit-test.sh` script will run tests against both the latest stable version of WordPress and the latest nightly build. This is useful for ensuring that your plugin or theme is compatible with the latest changes in WordPress core.
+
+If you would like to exclude the nightly tests, you can pass the `--skip-nightly` flag to the `phpunit-test.sh` script. This will only run tests against the latest stable version of WordPress.
+
+```json
+{
+	"scripts": {
+		"phpunit": "bin/phpunit-test.sh --skip-nightly",
+		"test": "@phpunit",
+	}
+}
+```
+
 ## Local Testing
 The `install-local-tests.sh` script is highly configurable to allow for a variety of local environment setups. Any parameter that could be passed into `install-wp-tests.sh` is set up as an optional flag in `install-local-tests.sh`. By default, the script with no flags will assume that a new database should be created as `root` with no password.
 

--- a/bin/phpunit-test.sh
+++ b/bin/phpunit-test.sh
@@ -7,6 +7,15 @@ source "$(dirname "$0")/helpers.sh"
 main() {
 	local DIRNAME
 	DIRNAME=$(dirname "$0")
+	local skip_nightly=false
+
+	# Super simple arg parsing
+	for arg in "$@"; do
+		if [[ "$arg" == "--skip-nightly" ]]; then
+			skip_nightly=true
+			break
+		fi
+	done
 
 	echo "🤔 Installing WP Unit tests..."
 	bash "${DIRNAME}/install-wp-tests.sh" --dbpass=root
@@ -19,6 +28,12 @@ main() {
 	echo '------------------------------------------'
 	echo "🏃‍♂️ [Run 2]: Running PHPUnit on Multisite"
 	WP_MULTISITE=1 composer phpunit --ansi
+
+	if $skip_nightly; then
+		echo "Skipping nightly WordPress tests..."
+		echo "Done! ✅"
+		return
+	fi
 
 	echo "🧹 Removing files before testing nightly WP..."
 	cleanup
@@ -37,4 +52,4 @@ main() {
 	echo "Done! ✅"
 }
 
-main
+main "$@"


### PR DESCRIPTION
Partially inspired by https://github.com/pantheon-systems/pantheon-advanced-page-cache/issues/335, this PR allows nightly tests to be skipped.

Skipping nightly tests is just a matter of passing a `--skip-nightly` flag to the `phpunit-test.sh` script.

This PR adds the flag to the script and documents the change in the readme.

Separately, this PR also adds @pantheon-systems/devrel to the CODEOWNERS file.